### PR TITLE
heater: Add new TURN_OFF_HEATERS command

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -260,7 +260,7 @@
 #gcode:
 #   A list of G-Code commands (one per line; subsequent lines
 #   indented) to execute on an idle timeout. The default is to run
-#   "M84".
+#   "TURN_OFF_HEATERS" and "M84".
 #timeout: 600
 #   Idle time (in seconds) to wait before running the above G-Code
 #   commands. The default is 600 seconds.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -96,6 +96,7 @@ The following standard commands are supported:
   cycles. If the WRITE_FILE parameter is enabled, then the file
   /tmp/heattest.txt will be created with a log of all temperature
   samples taken during the test.
+- `TURN_OFF_HEATERS`: Turn off all heaters.
 - `SET_VELOCITY_LIMIT [VELOCITY=<value>] [ACCEL=<value>]
   [ACCEL_TO_DECEL=<value>] [SQUARE_CORNER_VELOCITY=<value>]`: Modify
   the printer's velocity limits. Note that one may only set values

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 DEFAULT_IDLE_GCODE = """
+TURN_OFF_HEATERS
 M84
 """
 

--- a/klippy/heater.py
+++ b/klippy/heater.py
@@ -220,6 +220,10 @@ class PrinterHeaters:
         self.printer = config.get_printer()
         self.sensors = {}
         self.heaters = {}
+        # Register TURN_OFF_HEATERS command
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_command("TURN_OFF_HEATERS", self.cmd_TURN_OFF_HEATERS,
+                               desc=self.cmd_TURN_OFF_HEATERS_help)
     def add_sensor(self, sensor_type, sensor_factory):
         self.sensors[sensor_type] = sensor_factory
     def setup_heater(self, config):
@@ -249,6 +253,11 @@ class PrinterHeaters:
             raise self.printer.config_error("Unknown temperature sensor '%s'" % (
                 sensor_type,))
         return self.sensors[sensor_type](config)
+    cmd_TURN_OFF_HEATERS_help = "Turn off all heaters"
+    def cmd_TURN_OFF_HEATERS(self, params):
+        print_time = self.printer.lookup_object('toolhead').get_last_move_time()
+        for heater in self.heaters.values():
+            heater.set_temp(print_time, 0.)
 
 def add_printer_objects(config):
     config.get_printer().add_object('heater', PrinterHeaters(config))


### PR DESCRIPTION
Add a command that will turn off all heaters in the printer.  Run this
command in the default idle_timeout action.

Signed-off-by: Kevin O'Connor <kevin@koconnor.net>